### PR TITLE
Update writer_cif

### DIFF
--- a/crystals/writers.py
+++ b/crystals/writers.py
@@ -114,7 +114,7 @@ def write_cif(crystal: "Crystal", fname: PathLike):
     # and not the asymmetric unit cell + symmetry operators
     # This is valid CIF! And it is much simpler to implement
     # TODO: how to determine asymmetric cell + symmetry operations?
-    atoms = list(crystal.primitive().unitcell)
+    atoms = list(crystal.unitcell)
     symbols = [atm.symbol for atm in atoms]
     xf = [atm.coords_fractional[0] for atm in atoms]
     yf = [atm.coords_fractional[1] for atm in atoms]


### PR DESCRIPTION
fixed problem that writer_cif method uses lattice vectors of full unit cell but uses atom position of primitive unit cell. Now lattice and atom position of full unit-cell are used for cif export